### PR TITLE
pass source.options to the render function

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ internals.marshal = function (request, next) {
             return next(null, source);
         break;
         case 'view':
-            return request.server.render(source.template, source.context, function (err, rendered) {
+            return request.server.render(source.template, source.context, source.options, function (err, rendered) {
 
                 if (err) {
                     throw err;

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ internals.marshal = function (request, next) {
             return next(null, source);
         break;
         case 'view':
-            return request.server.render(source.template, source.context, source.options, function (err, rendered) {
+            return request.render(source.template, source.context, source.options, function (err, rendered) {
 
                 if (err) {
                     throw err;


### PR DESCRIPTION
if the response uses a different layout than the default, it won't be rendered using it's preferred layout
thus matching etags will be generated for changes that might have happen on the layout.